### PR TITLE
Fix issue with cached data persisting after different users log in

### DIFF
--- a/src/app/store.js
+++ b/src/app/store.js
@@ -1,4 +1,4 @@
-import { configureStore } from '@reduxjs/toolkit';
+import { configureStore, combineReducers } from '@reduxjs/toolkit';
 import logger from 'redux-logger';
 import classesReducer from '../pages/classesPage/classesPageSlice';
 import reservationsReducer from '../pages/reservationsPage/reservationsPageSlice';
@@ -6,14 +6,23 @@ import sessionReducer from '../auth/sessionSlice';
 import citiesReducer from '../pages/reservePage/citiesSlice';
 import classDetailsReducer from '../pages/classDetailsPage/classDetailsPageSlice';
 
+const appReducer = combineReducers({
+  classes: classesReducer,
+  classDetails: classDetailsReducer,
+  cities: citiesReducer,
+  reservations: reservationsReducer,
+  users: sessionReducer,
+});
+
+const rootReducer = (state, action) => {
+  if (action.type === 'session/logoutUser/fulfilled') {
+    return appReducer(undefined, action);
+  }
+  return appReducer(state, action);
+};
+
 const store = configureStore({
-  reducer: {
-    classes: classesReducer,
-    classDetails: classDetailsReducer,
-    cities: citiesReducer,
-    reservations: reservationsReducer,
-    users: sessionReducer,
-  },
+  reducer: rootReducer,
   middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(logger),
 });
 


### PR DESCRIPTION
In this PR I configured the Redux store to reset the global state after a user logs out from the app, to avoid persisting data from another user's previous session.